### PR TITLE
fix: Force Cargo to use git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ RUN yarn build
 
 FROM rust:slim as server
 
-RUN apt update && apt install -y pkg-config libssl-dev
+RUN apt update && apt install -y pkg-config libssl-dev git
 RUN rustup set profile minimal
 RUN rustup default nightly
+
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 RUN USER=root cargo new --bin blackhole
 WORKDIR /blackhole

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -11,9 +11,11 @@ RUN yarn build
 
 FROM rust:alpine as server
 
-RUN apk add musl-dev pkgconfig openssl-dev
+RUN apk add musl-dev pkgconfig openssl-dev git
 RUN rustup set profile minimal
 RUN rustup default nightly
+
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 RUN USER=root cargo new --bin blackhole
 WORKDIR /blackhole


### PR DESCRIPTION
The Docker builds were consuming too much memory, forcing them to be killed on the Github Runners. This was happening during the cloning process of cargo. `CARGO_NET_GET_FETCH_WITH_CLI` can be used to force cargo to instead use git, which lowers the memory consumption of cargo.